### PR TITLE
Small changes to viewer css - haven't addressed transparency issue

### DIFF
--- a/src/styles/viewerjs.css
+++ b/src/styles/viewerjs.css
@@ -10,7 +10,8 @@ div.view-renders{
   height: 100%;
   width: 100%;
   border: 1px solid #DDE8BB;
-  background-color: rgb(51,51,51);
+  background-color: black;
+  font-family: 'Karla';
 }
 
 /*================================================= single renderer ================================================== */
@@ -20,15 +21,16 @@ div.view-renders{
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   position: absolute;
-  background-color: rgb(51,51,51);
+  background-color: black;
 }
 
 /*================================================= patient info in renderer ================================================== */
 .view-render-info{
   position: absolute;
   z-index: 9999;
-  color: white;
-  font-size: small;
+  color: #DDE8BB;
+  font-size: 11px;
+  background-color: black;
 }
 .view-render-info-topleft{
   top: 2px;
@@ -61,7 +63,7 @@ div.view-toolbar{
   height: 30px;
   width: 100%;
   text-align:center;
-  background-color: rgb(51,51,51);
+  background-color: black;
 }
 
 label.view-toolbar-label{
@@ -97,7 +99,7 @@ div.view-thumbnailbar{
   height: 100%;
   width: 115px;
   overflow: auto;
-  background-color: rgb(51,51,51);
+  background-color: black;
 }
 
 /*thumbnail image frames (divs) within the thumbnail bar*/
@@ -120,8 +122,8 @@ div.view-thumbnailbar{
 
 /*text info within a thumbnail frame*/
 .view-thumbnail-info{
-  font-size: 12px;
+  font-size: 11px;
   text-align:center;
-  background-color: rgb(51,51,51);
-  color: white;
+  background-color: black;
+  color: #DDE8BB;
 }

--- a/src/styles/viewerjs.css
+++ b/src/styles/viewerjs.css
@@ -11,7 +11,7 @@ div.view-renders{
   width: 100%;
   border: 1px solid #DDE8BB;
   background-color: black;
-  font-family: 'Karla';
+  font-family: 'Droid Sans', sans-serif;
 }
 
 /*================================================= single renderer ================================================== */


### PR DESCRIPTION
I changed the background color of the main divs as well as some font sizes, colors etc. 
For the info div overlapping with the image, I think there are two ways around it:
- add a transparent .png as a background image in every .view-render-info
- separate each .view-render-info in a "background" and a "text" component.

Just setting the global .view-render-info opacity to lower than 1 does not work since it affects the text as well...
